### PR TITLE
Update conf.yaml to add Logstash roadmap

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -128,13 +128,26 @@ contents:
         index:      docs/index.asciidoc
         abbr:       kibana
 
-    -
-        title:      Logstash
-        prefix:     en/logstash
-        repo:       logstash
-        index:      docs/index.asciidoc
-        abbr:       logstash
-        chunk:      1
+    -   title:      Logstash
+        sections:
+          -
+            title:      Logstash reference
+            prefix:     en/logstash
+            repo:       logstash
+            index:      docs/index.asciidoc
+            chunk:      1
+            abbr:       logstash
+
+          -
+            title:      Logstash roadmap
+            prefix:     en/logstash/roadmap
+            repo:       logstash
+            index:      docs/roadmap/index.asciidoc
+            toc:        1
+            abbr:       roadmap
+            branches:   [master]
+            current:    master
+            single:     1
 
     -
         title:      Elasticsearch for Apache Hadoop

--- a/conf.yaml
+++ b/conf.yaml
@@ -142,7 +142,7 @@ contents:
             title:      Logstash roadmap
             prefix:     en/logstash/roadmap
             repo:       logstash
-            index:      docs/roadmap/index.asciidoc
+            index:      docs/static/roadmap/index.asciidoc
             toc:        1
             abbr:       roadmap
             branches:   [master]


### PR DESCRIPTION
Created an overarching Logstash TOC entry, which has two subsections: Logstash reference and Logstash roadmap. 

Merge only after the following PR is merged and we confirm that Logstash roadmap docs made it over to logstash-docs staging: https://github.com/elasticsearch/logstash/pull/2673

cc: @clintongormley @suyograo 